### PR TITLE
Mark repository as archived project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# Read me
+# Archived Project
+
+This repository is kept as a historical archive.
+
+- It is not an active portfolio project.
+- It is not intended for ongoing feature or security maintenance.
+- The existing GitHub Pages deployment is an old snapshot and should not be treated as a current production site.
+
+If this project needs to be used again in the future, re-evaluate the deployment path and dependency state before resuming work.


### PR DESCRIPTION
Adds a short README note clarifying that this repo is kept only as a historical archive and should not be treated as an active production portfolio.